### PR TITLE
Fix background disappearing when moving right

### DIFF
--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -4,17 +4,21 @@ Level::Level(int width, int height, int groundY)
     : width_(width), height_(height), groundY_(groundY) {}
 
 void Level::render(SDL_Renderer* renderer, float cameraX) const {
+    int firstTile = static_cast<int>(cameraX) / TILE_SIZE - 1;
+    int lastTile = firstTile + width_ / TILE_SIZE + 3;
+
     for (int y = 0; y < height_ / TILE_SIZE + 1; ++y) {
-        for (int x = 0; x < width_ / TILE_SIZE + 2; ++x) {
-            int worldX = x * TILE_SIZE + (static_cast<int>(cameraX) % TILE_SIZE) - TILE_SIZE;
+        for (int x = firstTile; x < lastTile; ++x) {
+            int screenX = x * TILE_SIZE - static_cast<int>(cameraX);
             int worldY = y * TILE_SIZE;
-            bool dark = ((((worldX + static_cast<int>(cameraX)) / TILE_SIZE) + y) % 2) == 0;
+            bool dark = ((x + y) % 2) == 0;
             if (dark) SDL_SetRenderDrawColor(renderer, 50, 50, 50, 255);
             else SDL_SetRenderDrawColor(renderer, 100, 100, 100, 255);
-            SDL_Rect tileRect{worldX - static_cast<int>(cameraX), worldY, TILE_SIZE, TILE_SIZE};
+            SDL_Rect tileRect{screenX, worldY, TILE_SIZE, TILE_SIZE};
             SDL_RenderFillRect(renderer, &tileRect);
         }
     }
+
     SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);
-    SDL_RenderDrawLine(renderer, -cameraX, groundY_, width_ - cameraX, groundY_);
+    SDL_RenderDrawLine(renderer, 0, groundY_, width_, groundY_);
 }


### PR DESCRIPTION
## Summary
- Correct tile rendering to cover viewport based on camera position
- Draw ground line across the screen rather than level width

## Testing
- `cmake .. && make` *(fails: Package 'sdl2', required by 'virtual:world', not found)*
- `sudo apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68955330ca7c832eb9e186e7f68f7418