### PR TITLE
Make SDL2_image and SDL2_ttf optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find or fetch SDL2 (+ image/ttf)
 find_package(SDL2 REQUIRED)
-find_package(SDL2_image REQUIRED)
-find_package(SDL2_ttf REQUIRED)
+find_package(SDL2_image QUIET)
+find_package(SDL2_ttf QUIET)
 
 add_subdirectory(src)
 ```
@@ -73,7 +73,13 @@ add_subdirectory(src)
 file(GLOB ENGINE_SRC engine/*.cpp game/*.cpp)
 add_executable(platformer ${ENGINE_SRC} main.cpp)
 target_include_directories(platformer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(platformer PRIVATE SDL2::SDL2 SDL2::SDL2main SDL2_image::SDL2_image SDL2_ttf::SDL2_ttf)
+target_link_libraries(platformer PRIVATE SDL2::SDL2 SDL2::SDL2main)
+if(SDL2_image_FOUND)
+  target_link_libraries(platformer PRIVATE SDL2_image::SDL2_image)
+endif()
+if(SDL2_ttf_FOUND)
+  target_link_libraries(platformer PRIVATE SDL2_ttf::SDL2_ttf)
+endif()
 ```
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,15 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(SDL2 REQUIRED)
-find_package(SDL2_image REQUIRED)
-find_package(SDL2_ttf REQUIRED)
+find_package(SDL2_image QUIET)
+find_package(SDL2_ttf QUIET)
+
+if(NOT SDL2_image_FOUND)
+  message(STATUS "SDL2_image not found; image loading will be disabled")
+endif()
+
+if(NOT SDL2_ttf_FOUND)
+  message(STATUS "SDL2_ttf not found; font rendering will be disabled")
+endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This repository provides a scaffold for a 2D platformer built in modern C++ usin
 - `CMakeLists.txt` – top‑level build configuration.
 
 ## Build Instructions
-Ensure SDL2 along with its image and ttf extensions are installed on your system. On Debian/Ubuntu:
+Ensure SDL2 is installed on your system. Image and TTF support are optional and will be enabled automatically if the development packages are available. On Debian/Ubuntu:
 
 ```
-sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
+sudo apt-get install libsdl2-dev # optional: libsdl2-image-dev libsdl2-ttf-dev
 ```
 
 Then build the demo:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,12 @@
 file(GLOB ENGINE_SRC engine/*.cpp game/*.cpp)
 add_executable(platformer ${ENGINE_SRC} main.cpp)
 target_include_directories(platformer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(platformer PRIVATE SDL2::SDL2 SDL2::SDL2main SDL2_image::SDL2_image SDL2_ttf::SDL2_ttf)
+target_link_libraries(platformer PRIVATE SDL2::SDL2 SDL2::SDL2main)
+
+if(SDL2_image_FOUND)
+  target_link_libraries(platformer PRIVATE SDL2_image::SDL2_image)
+endif()
+
+if(SDL2_ttf_FOUND)
+  target_link_libraries(platformer PRIVATE SDL2_ttf::SDL2_ttf)
+endif()


### PR DESCRIPTION
## Summary
- Allow building the project without SDL2_image and SDL2_ttf by searching for them quietly and linking only when present
- Update build instructions to reflect optional SDL2_image/SDL2_ttf dependencies

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6895567e8404832ea785cff91cdc5c33