### PR TITLE
Fix include paths and update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository provides a scaffold for a 2D platformer built in modern C++ usin
 Ensure SDL2 is installed on your system. Image and TTF support are optional and will be enabled automatically if the development packages are available. On Debian/Ubuntu:
 
 ```
-sudo apt-get install libsdl2-dev # optional: libsdl2-image-dev libsdl2-ttf-dev
+sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
 ```
 
 Then build the demo:
@@ -27,7 +27,7 @@ Then build the demo:
 ```
 cmake -S . -B build
 cmake --build build
-./build/platformer
+./build/src/platformer
 ```
 
-The application creates an 800×600 window, clears it to black, and exits after a short delay.
+The executable is placed under `build/src/`. Running it creates an 800×600 window, clears it to black, and exits after a short delay.

--- a/src/engine/Application.cpp
+++ b/src/engine/Application.cpp
@@ -1,9 +1,9 @@
 #include "Application.hpp"
 #include "Config.hpp"
 #include "Input.hpp"
-#include "Player.hpp"
-#include "TileMap.hpp"
-#include "Physics.hpp"
+#include "game/Player.hpp"
+#include "game/TileMap.hpp"
+#include "game/Physics.hpp"
 
 #include <SDL.h>
 

--- a/src/engine/Input.hpp
+++ b/src/engine/Input.hpp
@@ -1,7 +1,9 @@
 #ifndef INPUT_HPP
 #define INPUT_HPP
 
-// Handles keyboard input state.
+#include <SDL.h>
+
+// Handles keyboard input state and SDL keyboard events.
 // Tracks left/right movement and jumping.
 class Input {
 public:
@@ -9,7 +11,7 @@ public:
     void update();
 
     // Process SDL keyboard events.
-    void handleEvent(const struct SDL_Event& e);
+    void handleEvent(const SDL_Event& e);
 
     bool left{false};   // true while 'A' held
     bool right{false};  // true while 'S' held


### PR DESCRIPTION
## Summary
- correct engine source includes for player, tile map, and physics headers
- include SDL2 in the input header and document its role
- clarify build instructions and executable location in README

## Testing
- `cmake .. && cmake --build .`
- `./platformer` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68955c225ab8832e836da6f501b4e4a4