### PR TITLE
Fix spacebar jump detection

### DIFF
--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -7,14 +7,18 @@ void Input::handleEvent(const SDL_Event& e) {
         switch (e.key.keysym.sym) {
             case SDLK_a: left = pressed; break;
             case SDLK_d: right = pressed; break;
-            case SDLK_SPACE: jump = pressed; break;
+            case SDLK_SPACE:
+                jump = pressed;
+                if (pressed && e.key.repeat == 0) m_jumpEvent = true;
+                break;
             case SDLK_LSHIFT: run = pressed; break;
         }
     }
 }
 
 void Input::update() {
-    jumpPressed = jump && !m_prevJump;
+    jumpPressed = (jump && !m_prevJump) || m_jumpEvent;
     m_prevJump = jump;
+    m_jumpEvent = false;
 }
 

--- a/src/engine/Input.hpp
+++ b/src/engine/Input.hpp
@@ -4,7 +4,8 @@
 #include <SDL.h>
 
 // Handles keyboard input state and SDL keyboard events.
-// Tracks left/right movement, jumping, and running.
+// Tracks left/right movement, jumping, and running. Captures a "jump pressed"
+// edge that survives quick taps within a single frame.
 class Input {
 public:
     // Update internal edge-triggered states (e.g., jumpPressed).
@@ -21,6 +22,7 @@ public:
 
 private:
     bool m_prevJump{false};
+    bool m_jumpEvent{false};
 };
 
 #endif // INPUT_HPP


### PR DESCRIPTION
## Summary
- capture spacebar taps even when pressed and released within one frame
- expose a temporary jump event flag to compute `jumpPressed`

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6895606e3558832eae5a3d05490edf53